### PR TITLE
#3 Token Manager, StartVC 수정 

### DIFF
--- a/beilsang/beilsang/Controller/Login/StartViewController.swift
+++ b/beilsang/beilsang/Controller/Login/StartViewController.swift
@@ -173,7 +173,9 @@ extension StartViewController {
                     sceneDelegate.changeRootViewController(homeVC)
                 }
             case .tokenExpired :
-                TokenManager.shared.refreshToken(accessToken: accessToken!, refreshToken: refreshToken!) { _ in }
+                TokenManager.shared.refreshToken(accessToken: accessToken!, refreshToken: refreshToken!) { _ in } callback: {
+                    self.SignUpToServer()
+                }
             case .networkFail:
                 // 서버 통신 실패 처리
                 print("네트워크 페일")

--- a/beilsang/beilsang/Data/Service/TokenManager.swift
+++ b/beilsang/beilsang/Data/Service/TokenManager.swift
@@ -9,18 +9,20 @@ import Foundation
 class TokenManager {
     
     static let shared = TokenManager()
-
-    func refreshToken(accessToken: String, refreshToken: String, completion: @escaping (NetworkResult<Any>) -> Void) {
+    
+    func refreshToken(accessToken: String, refreshToken: String, completion: @escaping (NetworkResult<Any>) -> Void, callback: (() -> Void)? = nil) {
         TokenService.shared.refreshToken(accessToken: accessToken, refreshToken: refreshToken) { result in
             switch result {
             case .success(let data):
                 guard let data = data as? TokenResponse else { return }
                 print("access Token refresh Success with data : \(data)")
-
+                
                 UserDefaults.standard.set(data.data?.accessToken, forKey: UserDefaultsKey.serverToken)
                 UserDefaults.standard.set(data.data?.refreshToken, forKey: UserDefaultsKey.refreshToken)
                 
                 completion(.success(data))
+                
+                callback?()
                 
             case .networkFail:
                 print("네트워크 페일")


### PR DESCRIPTION
토큰 재발급 로직 수정 

`import Foundation

class TokenManager {
    
    static let shared = TokenManager()
    
    func refreshToken(accessToken: String, refreshToken: String, completion: @escaping (NetworkResult<Any>) -> Void, callback: (() -> Void)? = nil) {
        TokenService.shared.refreshToken(accessToken: accessToken, refreshToken: refreshToken) { result in
            switch result {
            case .success(let data):
                guard let data = data as? TokenResponse else { return }
                print("access Token refresh Success with data : \(data)")
                
                UserDefaults.standard.set(data.data?.accessToken, forKey: UserDefaultsKey.serverToken)
                UserDefaults.standard.set(data.data?.refreshToken, forKey: UserDefaultsKey.refreshToken)
                
                completion(.success(data))
                
                callback?()
                
            case .networkFail:
                print("네트워크 페일")
                completion(.networkFail)
            case .tokenExpired :
                print("토큰 재발급 오류")
                completion(.tokenExpired)
            case .requestErr(let error):
                print("요청 페일 \(error)")
                completion(.requestErr(error))
            case .pathErr:
                print("경로 오류")
                completion(.pathErr)
            case .serverErr:
                print("서버 오류")
                completion(.serverErr)
            }
        }
    }
}`